### PR TITLE
Fixed requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pyperclip
 requests>=2.20.0
 
 # temporary until we fork pyicloud or something
--r pyicloud/requirements.txt
+-r src/pyicloud/requirements.txt


### PR DESCRIPTION
The line was -r pyicloud/requirements.txt, not -r src/pyicloud/requirements.txt. This has now been fixed, and pip install -r requirements.txt works again.